### PR TITLE
Add new wording about Secret Santa alternative names

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -308,7 +308,6 @@ footer a {
 .jumbotron a {
     color: white;
 }
-.jumbotron q,
 .jumbotron p {
     display: block;
     margin: 0 auto;
@@ -463,6 +462,20 @@ footer a {
     .sample-message img {
         margin-top: 1em;
     }
+}
+
+/**
+ * What
+ */
+.what-block {
+    max-width: 960px;
+    margin: 0 auto;
+    position: relative;
+}
+.what-block q,
+.what-block p {
+    font-size: 1.2em;
+    line-height: 1.5em;
 }
 
 /**

--- a/templates/content/homepage.html.twig
+++ b/templates/content/homepage.html.twig
@@ -11,8 +11,10 @@
             <div class="jumbotron-inner">
                 <h1>Throw a Secret Santa with<br> your team!</h1>
 
-                <q><strong>Secret Santa</strong> is a Western Christmas tradition in which members of a group or
-                    community are <strong>randomly</strong> assigned a person to whom they anonymously <strong>give a gift</strong>.</q>
+                <p>
+                    <strong>Randomly</strong> assign to each member of your <strong>team</strong> (colleagues, friends or family)
+                    a person to whom they anonymously <strong>give a gift</strong>.
+                </p>
 
                 <div class="actions">
                     <a class="action hvr-buzz" href="{{ path('run', { application: 'slack' }) }}">
@@ -33,6 +35,19 @@
                     </div>
                 </div>
             </div>
+        </div>
+
+        <div class="content what-block">
+            <h2 class="content-head is-center">What is a Secret Santa?</h2>
+
+            <q><strong>Secret Santa</strong> is a Western Christmas tradition in which members of a group or
+                community are <strong>randomly</strong> assigned a person to whom they anonymously <strong>give a gift</strong>.
+                The identity of the gift giver is a <strong>secret</strong> not to be revealed.</q>
+
+            <p>
+                This tradition is also known as "<strong>Kris Kringle</strong>" in Ireland, "<strong>Wichteln</strong>" or "<strong>Engerl und Bengerl</strong>" in Germany,
+                "<strong>Amigo invisible</strong>" in Spain and "<strong>Cacahuète</strong>" in Belgium.
+            </p>
         </div>
 
         <div class="content how-block">


### PR DESCRIPTION
Rewrite the description without quote:

![capture du 2018-10-28 17-44-30](https://user-images.githubusercontent.com/2021641/47618951-35319380-dad9-11e8-8114-98bab5b42b74.png)

Move and complete the quote from Wikipedia in a new paragraph and mention alternative names:

![capture du 2018-10-28 17-44-05](https://user-images.githubusercontent.com/2021641/47618950-35319380-dad9-11e8-87f0-2fa6d83d168d.png)
