### PR TITLE
Add 🔎 on the Search Bar to make it more visible

### DIFF
--- a/templates/santa/run.html.twig
+++ b/templates/santa/run.html.twig
@@ -38,7 +38,7 @@
                                     <span class="uncheck-all" id="all-unchecker" title="Uncheck all the visible users in the list below">Uncheck all</span>
                                 </div>
                                 <div class="search-wrapper">
-                                    <input autofocus placeholder="Search user by real name or username" type="text" id="user-search-input" autocomplete="off" />
+                                    <input autofocus placeholder="🔎 Search user by real name or username" type="text" id="user-search-input" autocomplete="off" />
                                     <span class="search-cleaner fas fa-times is-hidden" id="search-cleaner" title="Empty the query"></span>
                                 </div>
                             </div>


### PR DESCRIPTION
Looks like this:

![image](https://user-images.githubusercontent.com/225704/49172644-e9754280-f341-11e8-81d0-6bce67a382ca.png)

But will be different in other systems/browsers.