### PR TITLE
Add automatic retry message sending on timeout

### DIFF
--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -33,13 +33,13 @@ send_sample_message:
     methods:  POST
     defaults: { _controller: JoliCode\SecretSanta\Controller\SantaController::sendSampleMessage }
 
+send_messages:
+    path:     /send-messages/{hash}
+    defaults: { _controller: JoliCode\SecretSanta\Controller\SantaController::sendMessages }
+
 finish:
     path:     /finish/{hash}
     defaults: { _controller: JoliCode\SecretSanta\Controller\SantaController::finish }
-
-retry:
-    path:     /retry/{hash}
-    defaults: { _controller: JoliCode\SecretSanta\Controller\SantaController::retry }
 
 spoil:
     path:     /spoil

--- a/public/style.css
+++ b/public/style.css
@@ -484,6 +484,40 @@ footer a {
 }
 
 /**
+ * Send messages
+ */
+.send-messages {
+    padding: 0 2em;
+    max-width: 1080px;
+    margin: 0 auto;
+    margin-bottom: 4em;
+}
+.send-messages h2 {
+    margin-top: 2em;
+    color: #E03A4D;
+    text-align: center;
+}
+.send-messages p {
+    margin-top: 2em;
+}
+.send-messages progress {
+    margin-top: 5em;
+    max-width: 400px;
+    width: 80%;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    border: none;
+    color: #E03A4D;
+}
+.send-messages progress::-webkit-progress-value {
+    background-color: #E03A4D;
+}
+.send-messages progress::-moz-progress-bar {
+    background-color: #E03A4D;
+}
+
+/**
  * What
  */
 .what-block {
@@ -935,8 +969,8 @@ textarea {
 
 .spin {
     display: inline-block;
-    -webkit-animation: spin 10s infinite linear;
-    animation: spin 10s infinite linear;
+    -webkit-animation: spin 5s infinite linear;
+    animation: spin 5s infinite linear;
 }
 
 /**

--- a/src/Santa/MessageDispatcher.php
+++ b/src/Santa/MessageDispatcher.php
@@ -31,7 +31,7 @@ class MessageDispatcher
     /**
      * Send messages for remaining associations.
      *
-     * This method is limited to 20 seconds to be able to display nice error message instead of being timed out by hosting.
+     * This method is limited to 5 seconds to avoid being timed out by hosting.
      *
      * @throws MessageDispatchTimeoutException
      * @throws MessageSendFailedException
@@ -41,7 +41,7 @@ class MessageDispatcher
         $startTime = time();
 
         foreach ($secretSanta->getRemainingAssociations() as $giver => $receiver) {
-            if ((time() - $startTime) > 19) {
+            if ((time() - $startTime) > 5) {
                 throw new MessageDispatchTimeoutException($secretSanta);
             }
 

--- a/templates/content/faq.html.twig
+++ b/templates/content/faq.html.twig
@@ -64,8 +64,8 @@
                         </p>
                         <p>
                             The second step is to dispatch a private message to all the selected users. Even if you started
-                            a Secret Santa with a lot of participants, we will safely handle that. If the operation times out
-                            we will propose you to continue the sending as if nothing happened.
+                            a Secret Santa with a lot of participants, the application will send all the messages progressively.
+                            So there should not be any problem here.
                         </p>
                     </li>
                     <li id="invalid-user">

--- a/templates/santa/finish.html.twig
+++ b/templates/santa/finish.html.twig
@@ -48,7 +48,7 @@
                 </p>
 
                 <div class="is-center">
-                    <a href="{{ path('retry', {hash: secretSanta.hash}) }}" class="big-button warning-btn" id="retry-button">
+                    <a href="{{ path('send_messages', {hash: secretSanta.hash}) }}" class="big-button warning-btn" id="retry-button">
                         <span class="fas fa-exclamation-triangle" aria-hidden="true"></span>
                         Continue - Send the remaining messages
                     </a>
@@ -64,7 +64,7 @@
                     {% endfor %}
                 </div>
 
-                <p>Note that errors are often due to <strong>temporary network problems</strong> when sending messages or if your secret santa has <strong>lot of users</strong>.</p>
+                <p>Note that errors are often due to <strong>temporary network problems</strong> when sending messages.</p>
 
                 <script type="text/javascript" nonce="{{ csp_nonce('script') }}">
                     let secretSantaRetried = false;

--- a/templates/santa/run.html.twig
+++ b/templates/santa/run.html.twig
@@ -101,7 +101,7 @@
 
                                         <p class="help hidden" id="big-santa-warning">
                                             When selecting a lot of participants, the final step (sending private messages)
-                                            can take some time (up to 20 secondes).<br />
+                                            can take some time.<br />
                                             Don't worry, in case something goes wrong, a "Retry" button will allow you to
                                             send remaining messages not yet sent.
                                         </p>

--- a/templates/santa/send_messages.html.twig
+++ b/templates/santa/send_messages.html.twig
@@ -1,0 +1,67 @@
+{% extends 'layout.html.twig' %}
+
+{% block content %}
+    <div class="content send-messages is-center">
+        <h2>
+            <span class="fas fa-spinner spin"></span>
+            &nbsp;
+            We are sending private messages!
+        </h2>
+
+        <p>
+            <strong>Do not close the window!</strong><br />
+            You will be redirected to the finish page automatically once all the messages were sent.
+        </p>
+
+        <progress id="count-progress" value="0" max="{{ secretSanta.associations|length }}">
+            <span class="js-count-value">0</span> / {{ secretSanta.associations|length }} messages sent.
+        </progress>
+
+        <p>
+            <span class="js-count-value">0</span> / {{ secretSanta.associations|length }} messages sent so far.
+            <br />
+            <small>Note: the progress is refreshed every 5 seconds.</small>
+        </p>
+    </div>
+
+    <script type="text/javascript" nonce="{{ csp_nonce('script') }}">
+        const countProgress = document.getElementById('count-progress');
+        const countValues = document.querySelectorAll('.js-count-value');
+
+        function sendRemainingMessages() {
+            fetch('{{ url('send_messages', {hash: secretSanta.hash}) }}', {
+              method: 'post',
+              credentials: 'include',
+              headers: {'X-Requested-With': 'XMLHttpRequest'},
+            })
+                .then(function(response) {
+                    return response.json();
+                })
+                .then(function(response) {
+                    updateProgress(response.count);
+
+                    if (response.finished) {
+                        window.location.href = '{{ url('finish', {hash: secretSanta.hash}) }}';
+
+                        return;
+                    }
+
+                    // Use setTimeout to not stack all the call
+                    setTimeout(sendRemainingMessages, 0);
+                })
+        }
+
+        function updateProgress(count) {
+            countProgress.value = count;
+
+            for(let i=0; i<countValues.length; i++) {
+                countValues[i].innerHTML = count;
+            }
+        }
+
+        (function() {
+            updateProgress({{ secretSanta.associations|length - secretSanta.remainingAssociations|length }});
+            sendRemainingMessages();
+        })();
+    </script>
+{% endblock content %}


### PR DESCRIPTION
Fix #100

Replace the retry workflow.

When submitting the form, the santa is saved in session then the user is redirected to this page (note: this new page can be safely refreshed):

![capture d ecran de 2018-12-01 22-59-43](https://user-images.githubusercontent.com/2021641/49333348-9c9da000-f5bd-11e8-9339-54887f24f181.png)

Javascript will continously ask the server to send the remaining message as soon a timeout is reached. At each timeout iteration, the progress bar is updated - timeout was lowered to 5 seconds to allow the progress bar to be refreshed more often, should make user more confident.

When all the messages are sent or if an error happened, the user is redirected to the finish page, as before.