### PR TITLE
Increase session duration

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -64,10 +64,3 @@ services:
     session.handler.predis:
         class: Predis\Session\Handler
         autowire: true
-
-    GuzzleHttp\Client:
-        arguments:
-            $config: {timeout: 5}
-
-    GuzzleHttp\ClientInterface:
-        alias: GuzzleHttp\Client

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -64,3 +64,6 @@ services:
     session.handler.predis:
         class: Predis\Session\Handler
         autowire: true
+        arguments:
+            $options:
+                gc_maxlifetime: 7200


### PR DESCRIPTION
Fix #110 

Note: by default, Predis session handler [uses](https://github.com/nrk/predis/blob/v1.1/src/Session/Handler.php#L42) the `session.gc_maxlifetime` PHP config with seems to be 1440 by default.

We will now use a lifetime of 2 hours.

Note 2: Symfony session lives 4 days but as the redis key expire before this does not change anything
Note 3: Cookie session lives the whole browser session time