### PR TITLE
Highlight target name in Secret Message to prevent confusion.

### DIFF
--- a/src/Slack/MessageSender.php
+++ b/src/Slack/MessageSender.php
@@ -54,8 +54,8 @@ class MessageSender
                 'type' => 'mrkdwn',
                 'text' => implode("\n:gift:\n:gift:\t\t\t", [
                     '',
-                    "*You have been chosen to gift:*",
-                    sprintf(":point_right:\t*<@%s>%s*\t:point_left:\t", $receiver, str_repeat('  ', strlen('@' . $receiver) % 2)),
+                    '*You have been chosen to gift:*',
+                    sprintf(":point_right:\t*<@%s>%s*\t:point_left:\t", $receiver, str_repeat('  ', \strlen('@' . $receiver) % 2)),
                     '',
                 ]),
             ],

--- a/src/Slack/MessageSender.php
+++ b/src/Slack/MessageSender.php
@@ -47,13 +47,17 @@ class MessageSender
                 'text' => sprintf("Hi!\nYou have been chosen to be part of a Secret Santa :santa:!\n\n"),
             ],
         ];
-
         $receiverUser = $secretSanta->getUser($receiver);
         $receiverBlock = [
             'type' => 'section',
             'text' => [
                 'type' => 'mrkdwn',
-                'text' => sprintf("*You have been chosen to gift:*\n\n:gift: *<@%s>* :gift:\n\n", $receiver),
+                'text' => implode("\n:gift:\n:gift:\t\t\t", [
+                    '',
+                    "*You have been chosen to gift:*",
+                    sprintf(":point_right:\t*<@%s>%s*\t:point_left:\t", $receiver, str_repeat('  ', strlen('@' . $receiver) % 2)),
+                    '',
+                ]),
             ],
         ];
 
@@ -72,6 +76,10 @@ class MessageSender
 
         if (!empty($secretSanta->getAdminMessage())) {
             $blocks[] = [
+                'type' => 'divider',
+            ];
+
+            $blocks[] = [
                 'type' => 'section',
                 'text' => [
                     'type' => 'mrkdwn',
@@ -79,21 +87,13 @@ class MessageSender
                 ],
             ];
 
+            $fallbackText .= sprintf("\n\nHere is a message from the Secret Santa admin _(<@%s>)_:\n\n```%s```", $secretSanta->getAdmin()->getIdentifier(), $secretSanta->getAdminMessage());
+
             $blocks[] = [
                 'type' => 'section',
                 'text' => [
                     'type' => 'mrkdwn',
                     'text' => $secretSanta->getAdminMessage(),
-                ],
-            ];
-
-            $fallbackText .= sprintf("\n\nHere is a message from the Secret Santa admin _(<@%s>)_:\n\n```%s```", $secretSanta->getAdmin()->getIdentifier(), $secretSanta->getAdminMessage());
-        } else {
-            $blocks[] = [
-                'type' => 'section',
-                'text' => [
-                    'type' => 'mrkdwn',
-                    'text' => sprintf('_If you have any question please ask your Secret Santa Admin: <@%s>_', $secretSanta->getAdmin()->getIdentifier()),
                 ],
             ];
         }
@@ -106,6 +106,7 @@ class MessageSender
             'type' => 'context',
             'elements' => [
                 ['type' => 'plain_text', 'text' => 'That\'s a secret only shared with you! Someone has also been chosen to get you a gift.'],
+                ['type' => 'mrkdwn', 'text' => sprintf('_If you have any question please ask your Secret Santa Admin: <@%s>_', $secretSanta->getAdmin()->getIdentifier()) . "\n"],
                 ['type' => 'mrkdwn', 'text' => 'Powered by <https://secret-santa.team/|Secret-Santa.team>'],
             ],
         ];


### PR DESCRIPTION
This PR is a proposal to address the problem describer in #119 

- The target's tag name is highlighted by being in the center of the message.
- The administrator tag name remain but is moved to the footer.

Here's how it would look on Slack:

![capture d ecran 2019-02-28 a 16 09 21](https://user-images.githubusercontent.com/1846873/53576682-87acba80-3b74-11e9-86b6-1dad3db20867.png)

---

Fix #119 