### PR TITLE
Ensure shuffle's seed change everytime

### DIFF
--- a/src/Santa/Rudolph.php
+++ b/src/Santa/Rudolph.php
@@ -27,6 +27,7 @@ class Rudolph
         $userCount = \count($users);
         $associations = [];
 
+        mt_srand();
         shuffle($users);
 
         for ($i = 1; $i < $userCount; ++$i) {


### PR DESCRIPTION
Not sure we need it but I just got an issue with shuffle on a private project. Shuffle always outputted the same array (no idea why) and the only fix we found was to call `mt_srand()` before `shuffle()`

Not tested yet :man_shrugging: 