### PR TITLE
Refactor the Discord Api Helper to use the RateLimiter

### DIFF
--- a/src/Discord/ApiHelper.php
+++ b/src/Discord/ApiHelper.php
@@ -20,6 +20,8 @@ class ApiHelper
 {
     const TOKEN_TYPE_BOT = 'Bot';
     private $botToken;
+    
+    /** @var DiscordClient|null */
     private $client;
 
     public function __construct(string $discordBotToken)

--- a/src/Discord/ApiHelper.php
+++ b/src/Discord/ApiHelper.php
@@ -19,9 +19,8 @@ use RestCord\Model\Permissions\Role;
 class ApiHelper
 {
     const TOKEN_TYPE_BOT = 'Bot';
-    const TOKEN_TYPE_OAUTH = 'OAuth';
-
     private $botToken;
+    private $client;
 
     public function __construct(string $discordBotToken)
     {
@@ -30,7 +29,7 @@ class ApiHelper
 
     public function getGuild(int $guildId): Guild
     {
-        $client = $this->getClient($this->botToken, self::TOKEN_TYPE_BOT);
+        $client = $this->getClient();
 
         return $client->guild->getGuild([
             'guild.id' => $guildId,
@@ -42,7 +41,7 @@ class ApiHelper
      */
     public function getMembersInGuild(int $guildId, int $after = null): array
     {
-        return $this->getClient($this->botToken, self::TOKEN_TYPE_BOT)->guild->listGuildMembers([
+        return $this->getClient()->guild->listGuildMembers([
             'guild.id' => $guildId,
             'limit' => 200,
             'after' => $after,
@@ -54,7 +53,7 @@ class ApiHelper
      */
     public function getRolesInGuild(int $guildId): array
     {
-        return $this->getClient($this->botToken, self::TOKEN_TYPE_BOT)->guild->getGuildRoles([
+        return $this->getClient()->guild->getGuildRoles([
             'guild.id' => $guildId,
             'limit' => 100,
         ]);
@@ -62,7 +61,7 @@ class ApiHelper
 
     public function sendMessage(int $userId, string $message): void
     {
-        $client = $this->getClient($this->botToken, self::TOKEN_TYPE_BOT);
+        $client = $this->getClient();
 
         $channel = $client->user->createDm([
             'recipient_id' => $userId,
@@ -74,11 +73,15 @@ class ApiHelper
         ]);
     }
 
-    private function getClient(string $token, string $tokenType): DiscordClient
+    private function getClient(): DiscordClient
     {
-        return new DiscordClient([
-            'token' => $token,
-            'tokenType' => $tokenType,
-        ]);
+        if (!($this->client instanceof DiscordClient)) {
+            $this->client = new DiscordClient([
+                'token' => $this->botToken,
+                'tokenType' => self::TOKEN_TYPE_BOT,
+            ]);
+        }
+
+        return $this->client;
     }
 }


### PR DESCRIPTION
See #167 

The HTTP Client we use have a ratelimiter: https://github.com/restcord/restcord/blob/master/src/RateLimit/RateLimiter.php
By default the state is stored in memory.

Our previous implementation was always rebuiling a new Client, so in the extractForGuild loop, it was always a fresh client and fresh rate limiter without the informations from the previous request.

This PR use always the same Client and that should allow us to benefit from the RateLimiter for user extraction AND message sending.