### PR TITLE
Use latest Slack auth

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,9 +47,11 @@
         "phpstan/phpstan-symfony": "^0.12.8",
         "symfony/browser-kit": "*",
         "symfony/css-selector": "*",
+        "symfony/debug-bundle": "^5.1",
         "symfony/dotenv": "*",
         "symfony/phpunit-bridge": "*",
         "symfony/stopwatch": "*",
+        "symfony/var-dumper": "^5.1",
         "symfony/web-profiler-bundle": "*",
         "symfony/web-server-bundle": "~4.4"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "41b016eac2849f06d27f8eb660ce4b52",
+    "content-hash": "e3de7d0fdaea70a6b3930e38e22dda6c",
     "packages": [
         {
             "name": "adam-paterson/oauth2-slack",
@@ -6795,6 +6795,86 @@
                 }
             ],
             "description": "Symfony CssSelector Component",
+            "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-05-20T17:43:50+00:00"
+        },
+        {
+            "name": "symfony/debug-bundle",
+            "version": "v5.1.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/debug-bundle.git",
+                "reference": "3f4bcea52678eedf19260973217f5ae7b835edf5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/debug-bundle/zipball/3f4bcea52678eedf19260973217f5ae7b835edf5",
+                "reference": "3f4bcea52678eedf19260973217f5ae7b835edf5",
+                "shasum": ""
+            },
+            "require": {
+                "ext-xml": "*",
+                "php": ">=7.2.5",
+                "symfony/http-kernel": "^4.4|^5.0",
+                "symfony/twig-bridge": "^4.4|^5.0",
+                "symfony/var-dumper": "^4.4|^5.0"
+            },
+            "conflict": {
+                "symfony/config": "<4.4",
+                "symfony/dependency-injection": "<4.4"
+            },
+            "require-dev": {
+                "symfony/config": "^4.4|^5.0",
+                "symfony/dependency-injection": "^4.4|^5.0",
+                "symfony/web-profiler-bundle": "^4.4|^5.0"
+            },
+            "suggest": {
+                "symfony/config": "For service container configuration",
+                "symfony/dependency-injection": "For using as a service from the container"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Bundle\\DebugBundle\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony DebugBundle",
             "homepage": "https://symfony.com",
             "funding": [
                 {

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -17,4 +17,5 @@ return [
     Symfony\Bundle\WebServerBundle\WebServerBundle::class => ['dev' => true],
     Nelmio\SecurityBundle\NelmioSecurityBundle::class => ['all' => true],
     Bugsnag\BugsnagBundle\BugsnagBundle::class => ['all' => true],
+    Symfony\Bundle\DebugBundle\DebugBundle::class => ['dev' => true, 'test' => true],
 ];

--- a/src/Slack/ClientFactory.php
+++ b/src/Slack/ClientFactory.php
@@ -13,16 +13,24 @@ namespace JoliCode\SecretSanta\Slack;
 
 use JoliCode\Slack\Api\Client;
 use JoliCode\Slack\ClientFactory as DefaultClientFactory;
+use Psr\Http\Client\ClientInterface as PsrHttpClient;
 
 class ClientFactory
 {
+    private PsrHttpClient $httpClient;
+
     /** @var array<string, Client> */
     private $clientsByToken = [];
+
+    public function __construct(PsrHttpClient $httpClient)
+    {
+        $this->httpClient = $httpClient;
+    }
 
     public function getClientForToken(string $token): Client
     {
         if (!isset($this->clientsByToken[$token])) {
-            $this->clientsByToken[$token] = DefaultClientFactory::create($token);
+            $this->clientsByToken[$token] = DefaultClientFactory::create($token, $this->httpClient);
         }
 
         return $this->clientsByToken[$token];

--- a/src/Slack/MessageSender.php
+++ b/src/Slack/MessageSender.php
@@ -142,8 +142,7 @@ class MessageSender
 
         try {
             $response = $this->clientFactory->getClientForToken($token)->chatPostMessage([
-                'channel' => sprintf('@%s', $giver),
-                'username' => $isSample ? 'Secret Santa Preview' : 'Secret Santa Bot',
+                'channel' => $giver,
                 'icon_url' => 'https://secret-santa.team/images/logo.png',
                 'text' => $fallbackText,
                 'blocks' => json_encode($blocks),
@@ -181,7 +180,6 @@ Happy Secret Santa!',
         try {
             $response = $this->clientFactory->getClientForToken($token)->chatPostMessage([
                 'channel' => $secretSanta->getAdmin()->getIdentifier(),
-                'username' => 'Secret Santa Bot Spoiler',
                 'icon_url' => 'https://secret-santa.team/images/logo-spoiler.png',
                 'text' => $text,
             ]);

--- a/src/Slack/SlackProvider.php
+++ b/src/Slack/SlackProvider.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Secret Santa project.
+ *
+ * (c) JoliCode <coucou@jolicode.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace JoliCode\SecretSanta\Slack;
+
+use AdamPaterson\OAuth2\Client\Provider\Slack;
+
+/**
+ * Overrides Slack provider while https://github.com/adam-paterson/oauth2-slack/pull/25
+ * is not merged.
+ */
+class SlackProvider extends Slack
+{
+    public function getBaseAuthorizationUrl()
+    {
+        return 'https://slack.com/oauth/v2/authorize';
+    }
+
+    /**
+     * @param array<string,mixed> $params
+     */
+    public function getBaseAccessTokenUrl(array $params)
+    {
+        return 'https://slack.com/api/oauth.v2.access';
+    }
+}

--- a/src/Slack/UserExtractor.php
+++ b/src/Slack/UserExtractor.php
@@ -69,15 +69,7 @@ class UserExtractor
         $users = [];
 
         foreach ($slackUsers as $slackUser) {
-            $user = new User(
-                $slackUser->getId(),
-                $slackUser->getProfile()->getRealName(),
-                [
-                    'nickname' => $slackUser->getName(),
-                    'image' => $slackUser->getProfile()->getImage192(),
-                    'restricted' => $slackUser->getIsRestricted(),
-                ]
-            );
+            $user = $this->buildUserFromSlack($slackUser);
 
             $users[$user->getIdentifier()] = $user;
         }
@@ -114,5 +106,27 @@ class UserExtractor
         }
 
         return $groups;
+    }
+
+    public function getUser(string $token, string $id): User
+    {
+        $slackUser = $this->clientFactory->getClientForToken($token)->usersInfo([
+            'user' => $id,
+        ])->getUser();
+
+        return $this->buildUserFromSlack($slackUser);
+    }
+
+    private function buildUserFromSlack(ObjsUser $slackUser): User
+    {
+        return new User(
+            $slackUser->getId(),
+            $slackUser->getProfile()->getRealName(),
+            [
+                'nickname' => $slackUser->getName(),
+                'image' => $slackUser->getProfile()->getImage192(),
+                'restricted' => $slackUser->getIsRestricted(),
+            ]
+        );
     }
 }

--- a/symfony.lock
+++ b/symfony.lock
@@ -233,6 +233,21 @@
     "symfony/css-selector": {
         "version": "v5.1.7"
     },
+    "symfony/debug-bundle": {
+        "version": "4.1",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "4.1",
+            "ref": "f8863cbad2f2e58c4b65fa1eac892ab189971bea"
+        },
+        "files": [
+            "config/packages/dev/debug.yaml"
+        ]
+    },
+    "symfony/debug-pack": {
+        "version": "v1.0.8"
+    },
     "symfony/dependency-injection": {
         "version": "v5.1.7"
     },


### PR DESCRIPTION
Before 4th december, we need to move to v2 of Slack OAuth2 endpoint. The new version of our Slack must first be approved by Slack first before. Then we will need to publish it live and deploying this PR in production at the same time I guess.