### PR TITLE
Allow to send notes

### DIFF
--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -34,6 +34,10 @@ run:
     path:     /run/{application}
     controller: JoliCode\SecretSanta\Controller\SantaController::run
 
+notes:
+    path:     /notes/{application}
+    controller: JoliCode\SecretSanta\Controller\SantaController::notes
+
 send_sample_message:
     path:     /sample-message/{application}
     methods:  POST

--- a/public/style.css
+++ b/public/style.css
@@ -152,6 +152,11 @@ a {
 .big-button.warning-btn:hover {
     background-color: var(--color-warning-dark);
 }
+.big-button.bellow {
+    color: var(--color-primary);
+    border: 2px solid var(--color-primary);
+    background-color: transparent;
+}
 .hidden {
     position: absolute;
     width: 1px;
@@ -742,6 +747,10 @@ textarea {
     display: flex;
     align-items: center;
 }
+.user-list .user-item.notes {
+    min-height: 3.5em;
+}
+
 .user-list .no-result {
     min-height: 3em;
     vertical-align: middle;
@@ -755,8 +764,16 @@ textarea {
     display: none;
 }
 .user-list .user-item:hover {
-   background-color: var(--color-gray-light);
+    background-color: var(--color-gray-light);
     cursor: pointer;
+}
+.user-list .user-item.notes:hover {
+    background-color: transparent;
+    cursor: default;
+}
+.notes input[type="text"] {
+    margin-right: 20px;
+    width: 50%;
 }
 .user-list .user-item * {
     margin: 0 0 0 1em;

--- a/src/Discord/ApiHelper.php
+++ b/src/Discord/ApiHelper.php
@@ -20,7 +20,7 @@ class ApiHelper
 {
     const TOKEN_TYPE_BOT = 'Bot';
     private $botToken;
-    
+
     /** @var DiscordClient|null */
     private $client;
 

--- a/src/Discord/MessageSender.php
+++ b/src/Discord/MessageSender.php
@@ -50,6 +50,10 @@ Someone has also been chosen to get you a gift.', $receiver);
             $text .= "\n\nHere is a message from the Secret Santa admin:\n\n```" . $secretSanta->getAdminMessage() . '```';
         }
 
+        if (!empty($userNote = $secretSanta->getUserNote($receiver))) {
+            $text .= sprintf("\n\nHere is some notes about <@%s>:\n\n```%s```", $receiver, $userNote);
+        }
+
         if ($secretSanta->getAdmin()) {
             $text .= sprintf("\n\n_Your Secret Santa admin, <@%s>._", $secretSanta->getAdmin()->getIdentifier());
         }

--- a/src/Model/SecretSanta.php
+++ b/src/Model/SecretSanta.php
@@ -21,6 +21,7 @@ class SecretSanta
     private $remainingAssociations;
     private $admin;
     private $adminMessage;
+    private $notes;
 
     /** @var string[] */
     private $errors = [];
@@ -28,6 +29,7 @@ class SecretSanta
     /**
      * @param User[]                $users
      * @param array<string, string> $associations
+     * @param array<int, string>    $notes
      */
     public function __construct(
         string $application,
@@ -36,7 +38,8 @@ class SecretSanta
         array $users,
         array $associations,
         ?User $admin,
-        ?string $adminMessage
+        ?string $adminMessage,
+        array $notes = []
     ) {
         $this->application = $application;
         $this->organization = $organization;
@@ -46,6 +49,7 @@ class SecretSanta
         $this->remainingAssociations = $associations;
         $this->admin = $admin;
         $this->adminMessage = $adminMessage;
+        $this->notes = $notes;
     }
 
     public function getApplication(): ?string
@@ -74,6 +78,11 @@ class SecretSanta
     public function getUser(string $identifier): ?User
     {
         return $this->users[$identifier] ?? null;
+    }
+
+    public function getUserNote(string $identifier): string
+    {
+        return $this->notes[$identifier] ?? '';
     }
 
     /**

--- a/src/Slack/MessageSender.php
+++ b/src/Slack/MessageSender.php
@@ -98,6 +98,24 @@ class MessageSender
             ];
         }
 
+        if (!empty($userNote = $secretSanta->getUserNote($receiver))) {
+            $blocks[] = [
+                'type' => 'section',
+                'text' => [
+                    'type' => 'mrkdwn',
+                    'text' => sprintf('*Here is some notes about <@%s>:*', $receiver),
+                ],
+            ];
+
+            $blocks[] = [
+                'type' => 'section',
+                'text' => [
+                    'type' => 'mrkdwn',
+                    'text' => $userNote,
+                ],
+            ];
+        }
+
         $blocks[] = [
             'type' => 'divider',
         ];

--- a/src/Zoom/MessageSender.php
+++ b/src/Zoom/MessageSender.php
@@ -92,6 +92,21 @@ class MessageSender
             ];
         }
 
+        if (!empty($userNote = $secretSanta->getUserNote($receiver))) {
+            $body['content']['body'][] = [
+                'type' => 'message',
+                'text' => sprintf('*Here is some notes about <!%s|%s>:*',
+                    $receiver,
+                    $receiverUser->getName()
+                ),
+            ];
+
+            $body['content']['body'][] = [
+                'type' => 'message',
+                'text' => $userNote,
+            ];
+        }
+
         $body['content']['body'][] = [
             'type' => 'message',
             'text' => 'That\'s a secret only shared with you! Someone has also been chosen to get you a gift.'

--- a/templates/santa/application/notes_discord.html.twig
+++ b/templates/santa/application/notes_discord.html.twig
@@ -1,0 +1,22 @@
+{% extends 'santa/notes.html.twig' %}
+
+{% block user_item %}
+    <label class="user-item notes">
+        {% if user.extra.image %}
+            <img src="{{ user.extra.image }}" alt="{{ user.name }}" />
+        {% endif %}
+        <span>{{ user.name }}{% if user.extra.nickname %} ({{ user.extra.nickname }}){% endif %}</span>
+        {% if groups %}
+            <span class="user-groups">
+                {% for group in groups %}
+                    {% if user.identifier in group.userIds %}
+                        <span class="user-group">{{ group.name }}</span>
+                    {% endif %}
+                {% endfor %}
+            </span>
+        {% endif %}
+
+        <input name="users[]" type="hidden" value="{{ user.identifier }}">
+        <input name="notes[{{ user.identifier }}]" type="text" {% if key in input_placeholders|keys %}placeholder="{{ input_placeholders[key] }}"{% endif %} />
+    </label>
+{% endblock %}

--- a/templates/santa/application/notes_slack.html.twig
+++ b/templates/santa/application/notes_slack.html.twig
@@ -1,0 +1,20 @@
+{% extends 'santa/run.html.twig' %}
+
+{% block user_item %}
+    <label class="user-item notes">
+        <img src="{{ user.extra.image }}" alt="{{ user.name }}" />
+        <span>{{ user.name }} ({{ user.extra.nickname }})</span>
+        {% if groups %}
+            <span class="user-groups">
+                {% for group in groups %}
+                    {% if user.identifier in group.userIds %}
+                        <span class="user-group">{{ group.name }}</span>
+                    {% endif %}
+                {% endfor %}
+            </span>
+        {% endif %}
+
+        <input name="users[]" type="hidden" value="{{ user.identifier }}">
+        <input name="notes[{{ user.identifier }}]" type="text" {% if key in input_placeholders|keys %}placeholder="{{ input_placeholders[key] }}"{% endif %} />
+    </label>
+{% endblock %}

--- a/templates/santa/application/notes_zoom.html.twig
+++ b/templates/santa/application/notes_zoom.html.twig
@@ -1,0 +1,22 @@
+{% extends 'santa/run.html.twig' %}
+
+{% block user_item %}
+    <label class="user-item notes">
+        {% if user.extra.image %}
+            <img src="{{ user.extra.image }}" alt="{{ user.name }}" />
+        {% endif %}
+        <span>{{ user.name }}</span>
+        {% if groups %}
+            <span class="user-groups">
+                {% for group in groups %}
+                    {% if user.identifier in group.userIds %}
+                        <span class="user-group">{{ group.name }}</span>
+                    {% endif %}
+                {% endfor %}
+            </span>
+        {% endif %}
+
+        <input name="users[]" type="hidden" value="{{ user.identifier }}">
+        <input name="notes[{{ user.identifier }}]" type="text" {% if key in input_placeholders|keys %}placeholder="{{ input_placeholders[key] }}"{% endif %} />
+    </label>
+{% endblock %}

--- a/templates/santa/notes.html.twig
+++ b/templates/santa/notes.html.twig
@@ -1,0 +1,76 @@
+{% extends 'base.html.twig' %}
+
+{% set hasRestrictedUser = hasRestrictedUser|default(false) %}
+
+{% block content %}
+    <div class="run-block">
+        <form method="post" id="run_form" action="{{ path('run', { application: application }) }}">
+            <div class="pure-g">
+                <div class="pure-u-1 user-field run-step">
+                    <h2>Add notes for your participants</h2>
+
+                    {% apply spaceless %}
+                        <div class="user-list" id="user-list">
+                            {% set key = 0 %}
+                            {% set input_placeholders = {
+                                0: 'Add some notes ...',
+                                1: 'An address ;',
+                                2: 'A food allergy ;',
+                                3: 'Or whatever you want ...',
+                            } %}
+
+                            {% for user in users %}
+                                {% if user.identifier in selectedUsers %}
+                                    {% block user_item %}{% endblock %}
+                                    {% set key = key + 1 %}
+                                {% endif %}
+                            {% endfor %}
+                            <div class="no-result is-hidden" id="no-user-matching">
+                                No user matching.
+                            </div>
+                        </div>
+                    {% endapply %}
+                    <p class="help">
+                        A user's note will be sent to the selected participant to send him/her a gift .
+                    </p>
+                </div>
+
+                <div class="pure-u-1 pure-u-lg-1-2">
+                    <div class="run-column">
+                        <div class="message-field run-step">
+                            <h2>
+                                <label class="control-label" for="message">Check your message</label>
+                            </h2>
+
+                            <input type="hidden" name="message" value="{{ message }}" />
+                            <textarea name="message" id="message" rows="5" disabled="disabled">{{ message }}</textarea>
+                            <p class="help">
+                                This field is only here to check your message.
+                                If you want to edit it, please go to the previous page.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+                <div class="pure-u-1 pure-u-lg-1-2">
+                    <div class="run-column run-column-right">
+                        <div class="run-step">
+                            <h2>Ready?</h2>
+
+                            <p class="is-center">
+                                We are going to shuffle selected users and send them a private message to inform them
+                                of their peer name.
+                            </p>
+
+                            <div class="is-center">
+                                <button type="submit" class="big-button" id="submit-button">
+                                    <span class="fas fa-paper-plane" aria-hidden="true"></span>
+                                    Finish and send Secret Santa messages!
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </form>
+    </div>
+{% endblock content %}

--- a/templates/santa/run.html.twig
+++ b/templates/santa/run.html.twig
@@ -97,6 +97,11 @@
                                                 <span class="fas fa-paper-plane" aria-hidden="true"></span>
                                                 Finish and send Secret Santa messages!
                                             </button>
+
+                                            <button type="submit" class="big-button bellow" id="add-button" name="notesRedirect">
+                                                <span class="fas fa-user-edit" aria-hidden="true"></span>
+                                                Add notes for your participants before sending
+                                            </button>
                                         </div>
 
                                         <p class="is-center">


### PR DESCRIPTION
This PR will add a second step (if the admin wants to add notes) and fixes #136.

The new form:
![image](https://user-images.githubusercontent.com/944409/99451917-31bd0f00-2923-11eb-9d76-46f80e8f6cab.png)

I added a "Add notes for your participants before sending" button that will bring you to a second form:
![image](https://user-images.githubusercontent.com/944409/99452532-ec4d1180-2923-11eb-8399-945e58423697.png)
Where you can add notes on each lines.
Theses notes will be send to the gifter.

And the message output on Discord:
![image](https://user-images.githubusercontent.com/944409/99451621-bd826b80-2922-11eb-9ac7-7317973cce0f.png)
