### PR TITLE
Increase the PHP Session timeout to 3 hours

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -70,6 +70,3 @@ services:
     session.handler.predis:
         class: Predis\Session\Handler
         autowire: true
-        arguments:
-            $options:
-                gc_maxlifetime: 7200

--- a/infrastructure/docker/services/php-base/etc/php/7.4/mods-available/app-default.ini
+++ b/infrastructure/docker/services/php-base/etc/php/7.4/mods-available/app-default.ini
@@ -12,6 +12,7 @@ max_execution_time = 0
 always_populate_raw_post_data = -1
 upload_max_filesize = 20M
 post_max_size = 20M
+session.gc_maxlifetime = 10800
 [Date]
 date.timezone = UTC
 [Phar]

--- a/public/.user.ini
+++ b/public/.user.ini
@@ -1,0 +1,2 @@
+# 3h long session (this value is looked up by Predis too)
+session.gc_maxlifetime = 10800


### PR DESCRIPTION
We had:

- 2h TTL on Predis / Redis (from services.yaml)
- default PHP `session.gc_maxlifetime` to 24 minutes
- `cookie_lifetime` of 0 which is great

Now everything can last 3 hours, no more session disappearing in the middle of a Secret Santa.

Configuring a PHP.INI value on Clever Cloud require a .user.ini file in the Webroot (public?!), that's quite strange to have PHP configuration here but not a concern.

https://www.clever-cloud.com/doc/deploy/application/php/php-apps/#configure-your-php-application