### PR TITLE
docs: fix typo in templates/content/faq.html.twig

### DIFF
--- a/templates/content/faq.html.twig
+++ b/templates/content/faq.html.twig
@@ -25,7 +25,7 @@
                             Nothing 😚
                         </p>
                         <p>
-                            <strong>Detailled answer</strong>:
+                            <strong>Detailed answer</strong>:
                             We receive only the data mandatory to start the Secret Santa:
                             the list of users and usergroups in your organization.
                             Everything will be forgotten automatically after you finished the draw!


### PR DESCRIPTION
Hi,

This tiny PR will fix : 

- 1 typo in `templates/content/faq.html.twig`



Best! :robot: