### PR TITLE
Add Config object to remove session variables

### DIFF
--- a/src/Application/SlackApplication.php
+++ b/src/Application/SlackApplication.php
@@ -17,6 +17,7 @@ use JoliCode\SecretSanta\Slack\MessageSender;
 use JoliCode\SecretSanta\Slack\UserExtractor;
 use League\OAuth2\Client\Token\AccessTokenInterface;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -101,22 +102,25 @@ class SlackApplication implements ApplicationInterface
 
     public function configureMessageForm(FormBuilderInterface $builder): void
     {
-        $builder->add('scheduled_at', HiddenType::class, [
-            'constraints' => [
-                new GreaterThanOrEqual([
-                    'value' => (new \DateTime())->getTimestamp(),
-                    'message' => 'You cannot schedule a Secret Santa for a past date',
-                ]),
-                new LessThanOrEqual([
-                    'value' => (new \DateTime('+120 days'))->getTimestamp(),
-                    'message' => 'You cannot schedule a Secret Santa for over 120 days in the future',
-                ]),
-            ],
-        ])
-        ->add('scheduled_at_tz', DateTimeType::class, [
-            'widget' => 'single_text',
-            'required' => false,
-        ]);
+        $builder->add(
+            $builder->create('options', FormType::class)
+            ->add('scheduled_at', HiddenType::class, [
+                'constraints' => [
+                    new GreaterThanOrEqual([
+                        'value' => (new \DateTime())->getTimestamp(),
+                        'message' => 'You cannot schedule a Secret Santa for a past date',
+                    ]),
+                    new LessThanOrEqual([
+                        'value' => (new \DateTime('+120 days'))->getTimestamp(),
+                        'message' => 'You cannot schedule a Secret Santa for over 120 days in the future',
+                    ]),
+                ],
+            ])
+            ->add('scheduled_at_tz', DateTimeType::class, [
+                'widget' => 'single_text',
+                'required' => false,
+            ]))
+        ;
     }
 
     public function reset(): void

--- a/src/Application/SlackApplication.php
+++ b/src/Application/SlackApplication.php
@@ -104,23 +104,22 @@ class SlackApplication implements ApplicationInterface
     {
         $builder->add(
             $builder->create('options', FormType::class)
-            ->add('scheduled_at', HiddenType::class, [
-                'constraints' => [
-                    new GreaterThanOrEqual([
-                        'value' => (new \DateTime())->getTimestamp(),
-                        'message' => 'You cannot schedule a Secret Santa for a past date',
-                    ]),
-                    new LessThanOrEqual([
-                        'value' => (new \DateTime('+120 days'))->getTimestamp(),
-                        'message' => 'You cannot schedule a Secret Santa for over 120 days in the future',
-                    ]),
-                ],
-            ])
-            ->add('scheduled_at_tz', DateTimeType::class, [
-                'widget' => 'single_text',
-                'required' => false,
-            ]))
-        ;
+                ->add('scheduled_at', HiddenType::class, [
+                    'constraints' => [
+                        new GreaterThanOrEqual([
+                            'value' => (new \DateTime('+5 minutes'))->getTimestamp(),
+                            'message' => 'You can only schedule a Secret Santa for at least 5 minutes away in the future',
+                        ]),
+                        new LessThanOrEqual([
+                            'value' => (new \DateTime('+120 days'))->getTimestamp(),
+                            'message' => 'You cannot schedule a Secret Santa for over 120 days in the future',
+                        ]),
+                    ],
+                ])
+                ->add('scheduled_at_tz', DateTimeType::class, [
+                    'widget' => 'single_text',
+                    'required' => false,
+                ]));
     }
 
     public function reset(): void

--- a/src/Form/MessageType.php
+++ b/src/Form/MessageType.php
@@ -12,6 +12,7 @@
 namespace JoliCode\SecretSanta\Form;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -32,19 +33,20 @@ class MessageType extends AbstractType
                     ]),
                 ],
                 'error_bubbling' => true,
-            ]);
-        foreach ($options['selected-users'] as $userId) {
-            $builder->add('notes-' . $userId, TextType::class, [
-                'required' => false,
-                'constraints' => [
-                    new Length([
-                        'max' => 400,
-                        'maxMessage' => 'Each note should contain less than {{ limit }} characters',
-                    ]),
+            ])
+            ->add('notes', CollectionType::class, [
+                'entry_type' => TextType::class,
+                'entry_options' => [
+                    'constraints' => [
+                        new Length([
+                            'max' => 400,
+                            'maxMessage' => 'Each note should contain less than {{ limit }} characters',
+                        ]),
+                    ],
+                    'error_bubbling' => true,
                 ],
-                'error_bubbling' => true,
+                'required' => false,
             ]);
-        }
     }
 
     public function configureOptions(OptionsResolver $resolver): void

--- a/src/Model/Config.php
+++ b/src/Model/Config.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+ * This file is part of the Secret Santa project.
+ *
+ * (c) JoliCode <coucou@jolicode.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace JoliCode\SecretSanta\Model;
+
+class Config
+{
+    /**
+     * @param User[]               $availableUsers
+     * @param string[]             $selectedUsers
+     * @param array<int, string>   $notes
+     * @param array<string, mixed> $options
+     */
+    public function __construct(
+        private array $availableUsers,
+        private array $selectedUsers = [],
+        private ?string $message = '',
+        private array $notes = [],
+        private array $options = [],
+    ) {
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getSelectedUsers(): array
+    {
+        return $this->selectedUsers;
+    }
+
+    /**
+     * @param string[] $selectedUsers
+     */
+    public function setSelectedUsers(array $selectedUsers): void
+    {
+        $this->selectedUsers = $selectedUsers;
+    }
+
+    /**
+     * @return User[]
+     */
+    public function getAvailableUsers(): array
+    {
+        return $this->availableUsers;
+    }
+
+    /**
+     * @param User[] $availableUsers
+     */
+    public function setAvailableUsers(array $availableUsers): void
+    {
+        $this->availableUsers = $availableUsers;
+    }
+
+    public function getMessage(): ?string
+    {
+        return $this->message;
+    }
+
+    public function setMessage(?string $message): void
+    {
+        $this->message = $message;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getNotes(): array
+    {
+        return $this->notes;
+    }
+
+    /**
+     * @param string[] $notes
+     */
+    public function setNotes(array $notes): void
+    {
+        $this->notes = $notes;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function setOptions(array $options): void
+    {
+        $this->options = $options;
+    }
+}

--- a/src/Model/SecretSanta.php
+++ b/src/Model/SecretSanta.php
@@ -19,22 +19,14 @@ class SecretSanta
     /** @var string[] */
     private array $errors = [];
 
-    /**
-     * @param User[]                $users
-     * @param array<string, string> $associations
-     * @param array<int, string>    $notes
-     * @param array<string, mixed>  $options
-     */
+    /** @param array<string, string> $associations */
     public function __construct(
         private string $application,
         private string $organization,
         private string $hash,
-        private array $users,
         private array $associations,
         private ?User $admin,
-        private ?string $adminMessage,
-        private array $notes = [],
-        private array $options = []
+        private Config $config,
     ) {
         $this->remainingAssociations = $associations;
     }
@@ -54,22 +46,19 @@ class SecretSanta
         return $this->hash;
     }
 
-    /**
-     * @return User[]
-     */
-    public function getUsers(): array
+    public function getUserCount(): int
     {
-        return $this->users;
+        return \count($this->config->getSelectedUsers());
     }
 
     public function getUser(string $identifier): ?User
     {
-        return $this->users[$identifier] ?? null;
+        return $this->config->getAvailableUsers()[$identifier] ?? null;
     }
 
     public function getUserNote(string $identifier): string
     {
-        return $this->notes[$identifier] ?? '';
+        return $this->config->getNotes()[$identifier] ?? '';
     }
 
     /**
@@ -111,7 +100,7 @@ class SecretSanta
 
     public function getAdminMessage(): ?string
     {
-        return $this->adminMessage;
+        return $this->config->getMessage();
     }
 
     /**
@@ -119,7 +108,7 @@ class SecretSanta
      */
     public function getOptions(): array
     {
-        return $this->options;
+        return $this->config->getOptions();
     }
 
     /**
@@ -127,7 +116,7 @@ class SecretSanta
      */
     public function setOptions(array $options): void
     {
-        $this->options = $options;
+        $this->config->setOptions($options);
     }
 
     public function isDone(): bool
@@ -143,5 +132,15 @@ class SecretSanta
     public function addError(string $error): void
     {
         $this->errors[] = $error;
+    }
+
+    public function getConfig(): Config
+    {
+        return $this->config;
+    }
+
+    public function setConfig(Config $config): void
+    {
+        $this->config = $config;
     }
 }

--- a/src/Statistic/StatisticCollector.php
+++ b/src/Statistic/StatisticCollector.php
@@ -39,11 +39,11 @@ class StatisticCollector
         $this->client->incr("stats:year-app:$currentYear-$applicationCode");
         $this->client->incr("stats:app:$applicationCode");
         $this->client->incr('stats:total');
-        $this->client->incrby('stats:users', \count($secretSanta->getUsers()));
+        $this->client->incrby('stats:users', $secretSanta->getUserCount());
 
         $usersMax = (int) $this->client->get('stats:users-max');
-        if (\count($secretSanta->getUsers()) > $usersMax) {
-            $this->client->set('stats:users-max', \count($secretSanta->getUsers()));
+        if ($secretSanta->getUserCount() > $usersMax) {
+            $this->client->set('stats:users-max', $secretSanta->getUserCount());
         }
     }
 

--- a/templates/santa/application/message_slack.html.twig
+++ b/templates/santa/application/message_slack.html.twig
@@ -7,12 +7,12 @@
 
 {% block options %}
     <div class="user-field message-step">
-        <h3><label for="{{ form.scheduled_at_tz.vars.id }}">Want to schedule the message to a later date?</label></h3>
+        <h3><label for="{{ form.options.scheduled_at_tz.vars.id }}">Want to schedule the message to a later date?</label></h3>
 
         <p>If not, you can just leave this field <strong>empty</strong>.</p>
 
-        {{ form_widget(form.scheduled_at_tz) }}
-        {{ form_widget(form.scheduled_at, {attr: {style: 'display: none;'}}) }}
+        {{ form_widget(form.options.scheduled_at_tz) }}
+        {{ form_widget(form.options.scheduled_at, {attr: {style: 'display: none;'}}) }}
 
     </div>
 {% endblock %}
@@ -20,10 +20,10 @@
 
 {% block message_js %}
     <script  nonce="{{ csp_nonce('script') }}">
-        let displayedDate = document.querySelector('#{{ form.scheduled_at_tz.vars.id }}');
+        let displayedDate = document.querySelector('#{{ form.options.scheduled_at_tz.vars.id }}');
         if (displayedDate) {
             displayedDate.addEventListener('change', function () {
-                document.querySelector('#{{ form.scheduled_at.vars.id }}').value = Math.ceil(new Date(displayedDate.value).getTime() / 1000)
+                document.querySelector('#{{ form.options.scheduled_at.vars.id }}').value = Math.ceil(new Date(displayedDate.value).getTime() / 1000)
             })
         }
     </script>

--- a/templates/santa/application/participants_discord.html.twig
+++ b/templates/santa/application/participants_discord.html.twig
@@ -5,7 +5,7 @@
 {% macro userSummary(user) %}
     <span class="user-summary">
         {% if user.extra.image %}
-            <img src="{{ user.extra.image }}" alt="" />
+            <img src="{{ user.extra.image }}" alt=""/>
         {% endif %}
         <span>{{ user.name }}</span>
         <span data-uncheck-user="user-{{ user.identifier }}" class="fas fa-times" title="Unselect this user"></span>
@@ -13,7 +13,7 @@
 {% endmacro %}
 
 {% block user_item %}
-    {% set user = userForm.parent.vars.choices[userForm.vars.value].data %}
+    {% set user = userForm.parent.vars.choices[userForm.vars.name].data %}
 
     <label
             class="user-item"
@@ -30,7 +30,7 @@
         </div>
 
         {% if user.extra.image %}
-            <img src="{{ user.extra.image }}" alt="{{ user.name }}" />
+            <img src="{{ user.extra.image }}" alt="{{ user.name }}"/>
         {% endif %}
         <span>{{ user.name }}{% if user.extra.nickname %} ({{ user.extra.nickname }}){% endif %}</span>
         {% if groups %}
@@ -46,5 +46,6 @@
 {% endblock %}
 
 {% block disclaimer %}
-    <p>To receive their message, participants must allow direct messages from server members. (See <a href="{{ path('faq', {'_fragment': 'discord-server-dm'}) }}" target="_blank">F.A.Q</a>)</p>
+    <p>To receive their message, participants must allow direct messages from server members. (See <a
+                href="{{ path('faq', {'_fragment': 'discord-server-dm'}) }}" target="_blank">F.A.Q</a>)</p>
 {% endblock %}

--- a/templates/santa/application/participants_slack.html.twig
+++ b/templates/santa/application/participants_slack.html.twig
@@ -13,14 +13,13 @@
 {% endmacro %}
 
 {% block user_item %}
-    {% set user = userForm.parent.vars.choices[userForm.vars.value].data %}
+    {% set user = userForm.parent.vars.choices[userForm.vars.name].data %}
 
     <label
             class="user-item {{ user.extra.restricted ? 'restricted' : '' }}"
             for="{{ userForm.vars.id }}"
             data-search-index="{{ user.name ~ ' ' ~ user.extra.nickname }}"
     >
-
 
         <div class="data-summary"
              data-summary="{{ current.userSummary(user)|escape('html_attr')|raw }}">

--- a/templates/santa/application/participants_zoom.html.twig
+++ b/templates/santa/application/participants_zoom.html.twig
@@ -34,9 +34,11 @@
 {% endmacro %}
 
 {% block user_item %}
+    {% set user = userForm.parent.vars.choices[userForm.vars.name].data %}
+
     <label
-            class="user-item {{ user.extra.restricted ? 'restricted' : '' }}"
-            for="user-{{ user.identifier }}"
+            class="user-item"
+            for="{{ userForm.vars.id }}"
             data-search-index="{{ user.name }}"
     >
         <div class="data-summary"

--- a/templates/santa/message.html.twig
+++ b/templates/santa/message.html.twig
@@ -17,14 +17,14 @@
             {% if not form.vars.valid %}
                 <span class="error">
                     <i class="fas fa-exclamation-triangle"></i>
-                    {% for error in form.vars.errors %}<br>{{ error.message }} {% endfor %}
+                    {% for error in errors %}<br>{{ error }} {% endfor %}
                 </span>
             {% endif %}
 
             <div class="message-field message-step">
                 <h3>
                     <label class="control-label" for="{{ form.message.vars.id }}">Write an optional message <span class="message-length">(<span
-                                    data-length-field="message">{{ message|length }}</span>&nbsp;/&nbsp;800 characters)</span></label>
+                                    data-length-field="message">{{ form.message.vars.data|length }}</span>&nbsp;/&nbsp;800 characters)</span></label>
                 </h3>
 
                 <p>
@@ -58,9 +58,9 @@
                                 1: 'A food allergy ;',
                                 2: 'Or whatever you want ...',
                             } %}
-                            {% for userId in selectedUsers %}
-                                {% set user = availableUsers[userId] %}
-                                <label class="user-item notes" for="{{ form['notes-' ~ userId].vars.id }}">
+                            {% for child in form.notes %}
+                                {% set user = config.availableUsers[child.vars.name] %}
+                                <label class="user-item notes" for="{{ child.vars.id }}">
                                         <span class="user-column">
                                             <span class="user-data">
                                                 {% block user_item %}{% endblock %}
@@ -71,12 +71,12 @@
                                         </span>
 
                                     {% if key in input_placeholders|keys %}
-                                        {{ form_widget(form['notes-' ~ userId], { 'attr': {
+                                        {{ form_widget(child, { 'attr': {
                                             'placeholder': input_placeholders[key],
                                             'data-field': user.identifier
                                         }}) }}
                                     {% else %}
-                                        {{ form_widget(form['notes-' ~ userId],  { 'attr': {
+                                        {{ form_widget(child,  { 'attr': {
                                             'data-field': user.identifier
                                         }}) }}
                                     {% endif %}

--- a/templates/santa/participants.html.twig
+++ b/templates/santa/participants.html.twig
@@ -62,7 +62,7 @@
                                                 <div class="no-result is-hidden" id="no-user-matching">
                                                     No user matching.
                                                 </div>
-                                                {% for userForm in form.users %}
+                                                {% for userForm in form.selectedUsers %}
                                                     {% block user_item %}{% endblock %}
                                                 {% endfor %}
                                             </div>

--- a/tests/Controller/SantaControllerTest.php
+++ b/tests/Controller/SantaControllerTest.php
@@ -11,6 +11,7 @@
 
 namespace JoliCode\SecretSanta\Tests\Controller;
 
+use JoliCode\SecretSanta\Model\Config;
 use JoliCode\SecretSanta\Model\SecretSanta;
 use JoliCode\SecretSanta\Model\User;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -53,14 +54,18 @@ class SantaControllerTest extends BaseWebTestCase
 
     public function testFinishPageWorksWithValidHashForSuccessfulSecretSanta(): void
     {
+        $config = new Config([
+                'toto1' => new User('toto1', 'Toto 1'),
+                'toto2' => new User('toto2', 'Toto 2'),
+                'toto3' => new User('toto3', 'Toto 3'),
+            ],
+            ['toto1', 'toto2', 'toto3'],
+            'hello test');
+
         $secretSanta = new SecretSanta('my_application', 'toto', 'azerty', [
-            'toto1' => new User('toto1', 'Toto 1'),
-            'toto2' => new User('toto2', 'Toto 2'),
-            'toto3' => new User('toto3', 'Toto 3'),
-        ], [
             'toto1' => 'toto2',
             'toto2' => 'toto3',
-        ], null, null);
+        ], null, $config);
         $secretSanta->markAssociationAsProceeded('toto1');
         $secretSanta->markAssociationAsProceeded('toto2');
 
@@ -76,14 +81,18 @@ class SantaControllerTest extends BaseWebTestCase
 
     public function testFinishPageWorksWithValidHashForFailedSecretSanta(): void
     {
+        $config = new Config([
+                'toto1' => new User('toto1', 'Toto 1'),
+                'toto2' => new User('toto2', ''),
+                'toto3' => new User('toto3', 'Toto 3'),
+            ],
+            ['toto1', 'toto2', 'toto3'],
+            'hello test');
+
         $secretSanta = new SecretSanta('my_application', 'toto', 'azerty', [
-            'toto1' => new User('toto1', 'Toto 1'),
-            'toto2' => new User('toto2', ''),
-            'toto3' => new User('toto3', 'Toto 3'),
-        ], [
             'toto1' => 'toto2',
             'toto2' => 'toto3',
-        ], null, null);
+        ], null, $config);
         $secretSanta->addError('Knock knock. Who\'s there? A santa error!');
 
         $client = static::createClient();

--- a/tests/Santa/SpoilerTest.php
+++ b/tests/Santa/SpoilerTest.php
@@ -11,6 +11,7 @@
 
 namespace JoliCode\SecretSanta\Tests\Santa;
 
+use JoliCode\SecretSanta\Model\Config;
 use JoliCode\SecretSanta\Model\SecretSanta;
 use JoliCode\SecretSanta\Model\User;
 use JoliCode\SecretSanta\Santa\Spoiler;
@@ -28,19 +29,23 @@ class SpoilerTest extends TestCase
 
     public function testItEncodesSecretSantaInCurrentVersion(): void
     {
+        $config = new Config([
+                'user1' => new User('user1', 'User 1'),
+                'user2' => new User('user2', 'User 2'),
+                'user3' => new User('user3', 'User 3'),
+                'user4' => new User('user4', 'User 4'),
+                'user5' => new User('user5', 'User 5'),
+            ],
+            ['user1', 'user2', 'user3', 'user4', 'user5'],
+            'hello test');
+
         $secretSanta = new SecretSanta('my_application', 'toto', 'yolo', [
-            'user1' => new User('user1', 'User 1'),
-            'user2' => new User('user2', 'User 2'),
-            'user3' => new User('user3', 'User 3'),
-            'user4' => new User('user4', 'User 4'),
-            'user5' => new User('user5', 'User 5'),
-        ], [
             'user1' => 'user2',
             'user2' => 'user3',
             'user3' => 'user4',
             'user4' => 'user5',
             'user5' => 'user1',
-        ], null, null);
+        ], null, $config);
 
         $code = $this->SUT->encode($secretSanta);
         $expectedCode = 'v3@H4sIAAAAAAAAA4tWCi1OLVIwVNKBMIxgDGMYwwTGMFWKBQAbdZzDLgAAAA==';


### PR DESCRIPTION
Added an object that stores all the necessary data to create a Secret Santa, and passed it in session instead of all the variables that we used to.
Also updated the SecretSanta object with the same idea, replaced a bunch of parameters (not all) by one single $config parameter containing most of the data needed.

Tests and QA should be taken care of as well