### PR TITLE
Upgrade message dispatching

### DIFF
--- a/src/Controller/SantaController.php
+++ b/src/Controller/SantaController.php
@@ -15,7 +15,6 @@ use Bugsnag\Client;
 use JoliCode\SecretSanta\Application\ApplicationInterface;
 use JoliCode\SecretSanta\Exception\MessageDispatchTimeoutException;
 use JoliCode\SecretSanta\Exception\MessageSendFailedException;
-use JoliCode\SecretSanta\Exception\SecretSantaException;
 use JoliCode\SecretSanta\Form\MessageType;
 use JoliCode\SecretSanta\Form\ParticipantType;
 use JoliCode\SecretSanta\Model\Config;
@@ -307,16 +306,15 @@ class SantaController extends AbstractController
             $messageDispatcher->dispatchRemainingMessages($secretSanta, $application);
         } catch (MessageDispatchTimeoutException $e) {
             $timeout = true;
-        } catch (SecretSantaException $e) {
+        } catch (MessageSendFailedException $e) {
+            $secretSanta->addError($e->getMessage(), $e->getRecipient()->getIdentifier());
+
             $this->logger->error($e->getMessage(), [
                 'exception' => $e,
             ]);
-
             $this->bugsnag->notifyException($e, function ($report) {
                 $report->setSeverity('info');
             });
-
-            $secretSanta->addError($e->getMessage());
 
             $error = true;
         }
@@ -346,6 +344,16 @@ class SantaController extends AbstractController
         ]);
 
         return new Response($content);
+    }
+
+    #[Route('/retry/{hash}', name: 'retry', methods: ['GET'])]
+    public function retry(Request $request, string $hash): Response
+    {
+        $secretSanta = $this->getSecretSantaOrThrow404($request, $hash);
+
+        $secretSanta->resetErrors();
+
+        return $this->redirectToRoute('send_messages', ['hash' => $hash]);
     }
 
     #[Route('/cancel/{application}', name: 'cancel', methods: ['GET'])]

--- a/src/Model/SecretSanta.php
+++ b/src/Model/SecretSanta.php
@@ -77,12 +77,22 @@ class SecretSanta
         return $this->remainingAssociations;
     }
 
+    public function addError(string $error, string $giver): void
+    {
+        $this->errors[$giver] = $error;
+    }
+
     /**
      * @return string[]
      */
     public function getErrors(): array
     {
         return $this->errors;
+    }
+
+    public function resetErrors(): void
+    {
+        $this->errors = [];
     }
 
     /**
@@ -121,17 +131,18 @@ class SecretSanta
 
     public function isDone(): bool
     {
+        foreach ($this->errors as $user => $error) {
+            if (\array_key_exists($user, $this->remainingAssociations)) {
+                return false;
+            }
+        }
+
         return empty($this->remainingAssociations);
     }
 
     public function markAssociationAsProceeded(string $giver): void
     {
         unset($this->remainingAssociations[$giver]);
-    }
-
-    public function addError(string $error): void
-    {
-        $this->errors[] = $error;
     }
 
     public function getConfig(): Config

--- a/src/Santa/MessageDispatcher.php
+++ b/src/Santa/MessageDispatcher.php
@@ -29,14 +29,18 @@ class MessageDispatcher
     public function dispatchRemainingMessages(SecretSanta $secretSanta, ApplicationInterface $application): void
     {
         $startTime = time();
+        $failedUsers = $secretSanta->getErrors();
 
         foreach ($secretSanta->getRemainingAssociations() as $giver => $receiver) {
             if ((time() - $startTime) > 5) {
                 throw new MessageDispatchTimeoutException($secretSanta);
             }
 
-            $application->sendSecretMessage($secretSanta, $giver, $receiver);
+            if ($failedUsers[$giver] ?? false) {
+                continue;
+            }
 
+            $application->sendSecretMessage($secretSanta, $giver, $receiver);
             $secretSanta->markAssociationAsProceeded($giver);
         }
     }

--- a/templates/santa/finish.html.twig
+++ b/templates/santa/finish.html.twig
@@ -25,13 +25,13 @@
 
             <div class="result-error">
                 <p>
-                    Sometimes, even Santa run into problems when doing its job. But keep reading, everything is not lost!
+                    Sometimes, even Santa runs into problems when doing his job. But keep reading, everything is not lost!
                 </p>
 
                 <h3>We need you to send the remaining messages</h3>
 
                 <p>
-                    Here is the list of users that didn't reveive their Secret Santa message <strong>yet</strong> (click <button id="reveal" class="">here</button> to reveal the receivers):
+                    Here is the list of users that didn't receive their Secret Santa message <strong>yet</strong> (click <button id="reveal" class="">here</button> to reveal the receivers):
                 </p>
 
                 <ul>
@@ -54,11 +54,13 @@
 
                 <h3>Explanation</h3>
 
+                {% set errors = secretSanta.uniqueErrors %}
+
                 <p>
-                    For information, here is the evil error{{ secretSanta.uniqueErrors|length > 1 ? 's' }} that caused this failure:
+                    For information, here {{ errors|length > 1 ? 'are' : 'is' }} the evil error{{ errors|length > 1 ? 's' }} that caused this failure:
                 </p>
 
-                {% for error in secretSanta.uniqueErrors %}
+                {% for error in errors %}
                     <div class="error-code">
                         {% if loop.length > 1 %}- {% endif %}{{ error|raw }}
                     </div>
@@ -85,7 +87,7 @@
                 </p>
 
                 <div class="is-center">
-                    <a href="{{ path('send_messages', {hash: secretSanta.hash}) }}" class="big-button warning-btn" id="retry-button">
+                    <a href="{{ path('retry', {hash: secretSanta.hash}) }}" class="big-button warning-btn" id="retry-button">
                         <span class="fas fa-redo" aria-hidden="true"></span>
                         Continue - Send the remaining messages
                     </a>

--- a/tests/Controller/SantaControllerTest.php
+++ b/tests/Controller/SantaControllerTest.php
@@ -92,8 +92,9 @@ class SantaControllerTest extends BaseWebTestCase
         $secretSanta = new SecretSanta('my_application', 'toto', 'azerty', [
             'toto1' => 'toto2',
             'toto2' => 'toto3',
+            'toto3' => 'toto1',
         ], null, $config);
-        $secretSanta->addError('Knock knock. Who\'s there? A santa error!');
+        $secretSanta->addError('Knock knock. Who\'s there? A santa error!', 'toto1');
 
         $client = static::createClient();
         $this->prepareSession($client, 'secret-santa-azerty', $secretSanta);


### PR DESCRIPTION
Fix #224 

Made it so that all messages are sent to the participants, even when some don't go through.

All the messages that did not succeed are shown to the admin on the final page, from there they can choose to retry sending only these remaining messages.