### PR TITLE
Trim tokens for Slack and Discord

### DIFF
--- a/src/Application/SlackApplication.php
+++ b/src/Application/SlackApplication.php
@@ -11,11 +11,11 @@
 
 namespace JoliCode\SecretSanta\Application;
 
+use JoliCode\SecretSanta\Model\ApplicationToken;
 use JoliCode\SecretSanta\Model\SecretSanta;
 use JoliCode\SecretSanta\Model\User;
 use JoliCode\SecretSanta\Slack\MessageSender;
 use JoliCode\SecretSanta\Slack\UserExtractor;
-use League\OAuth2\Client\Token\AccessTokenInterface;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
@@ -63,7 +63,7 @@ class SlackApplication implements ApplicationInterface
 
     public function getOrganization(): string
     {
-        return $this->getToken()->getValues()['team']['name'] ?? '';
+        return $this->getToken()->getContext()['team'] ?? '';
     }
 
     public function getAdmin(): ?User
@@ -127,16 +127,16 @@ class SlackApplication implements ApplicationInterface
         $this->getSession()->remove(self::SESSION_KEY_ADMIN);
     }
 
-    public function setToken(AccessTokenInterface $token): void
+    public function setToken(ApplicationToken $token): void
     {
         $this->getSession()->set(self::SESSION_KEY_TOKEN, $token);
     }
 
-    private function getToken(): AccessTokenInterface
+    private function getToken(): ApplicationToken
     {
         $token = $this->getSession()->get(self::SESSION_KEY_TOKEN);
 
-        if (!$token instanceof AccessTokenInterface) {
+        if (!$token instanceof ApplicationToken) {
             throw new \LogicException('Invalid token.');
         }
 

--- a/src/Controller/DiscordController.php
+++ b/src/Controller/DiscordController.php
@@ -13,6 +13,7 @@ namespace JoliCode\SecretSanta\Controller;
 
 use JoliCode\SecretSanta\Application\DiscordApplication;
 use JoliCode\SecretSanta\Exception\AuthenticationException;
+use JoliCode\SecretSanta\Model\ApplicationToken;
 use JoliCode\SecretSanta\Model\User;
 use League\OAuth2\Client\Token\AccessToken;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -84,6 +85,11 @@ class DiscordController extends AbstractController
                 'code' => $request->query->get('code'),
             ]);
 
+            $appToken = new ApplicationToken($token->getToken(), [
+                'guildId' => $token->getValues()['guild']['id'],
+                'guildName' => $token->getValues()['guild']['name'],
+            ]);
+
             // Who Am I?
             /** @var DiscordResourceOwner $user */
             $user = $provider->getResourceOwner($token);
@@ -91,9 +97,8 @@ class DiscordController extends AbstractController
             throw new AuthenticationException(DiscordApplication::APPLICATION_CODE, 'Failed to retrieve data from Discord.', $e);
         }
 
-        $discordApplication->setToken($token);
+        $discordApplication->setToken($appToken);
         $discordApplication->setAdmin(new User($user->getId(), $user->getUsername()));
-        $discordApplication->setGuildId($request->query->getInt('guild_id'));
 
         return new RedirectResponse($this->router->generate('run', [
             'application' => $discordApplication->getCode(),

--- a/src/Controller/SlackController.php
+++ b/src/Controller/SlackController.php
@@ -13,6 +13,7 @@ namespace JoliCode\SecretSanta\Controller;
 
 use JoliCode\SecretSanta\Application\SlackApplication;
 use JoliCode\SecretSanta\Exception\AuthenticationException;
+use JoliCode\SecretSanta\Model\ApplicationToken;
 use JoliCode\SecretSanta\Slack\SlackProvider;
 use JoliCode\SecretSanta\Slack\UserExtractor;
 use League\OAuth2\Client\Token\AccessToken;
@@ -79,12 +80,14 @@ class SlackController extends AbstractController
                 'code' => $request->query->get('code'),
             ]);
 
+            $appToken = new ApplicationToken($token->getToken(), ['team' => $token->getValues()['team']['name']]);
+
             $admin = $userExtractor->getUser($token->getToken(), $token->getValues()['authed_user']['id']);
         } catch (\Exception $e) {
             throw new AuthenticationException(SlackApplication::APPLICATION_CODE, 'Failed to retrieve data from Slack.', $e);
         }
 
-        $slackApplication->setToken($token);
+        $slackApplication->setToken($appToken);
         $slackApplication->setAdmin($admin);
 
         return new RedirectResponse($this->router->generate('run', [

--- a/src/Discord/ApiHelper.php
+++ b/src/Discord/ApiHelper.php
@@ -12,7 +12,6 @@
 namespace JoliCode\SecretSanta\Discord;
 
 use RestCord\DiscordClient;
-use RestCord\Model\Guild\Guild;
 use RestCord\Model\Guild\GuildMember;
 use RestCord\Model\Permissions\Role;
 
@@ -24,15 +23,6 @@ class ApiHelper
 
     public function __construct(private string $discordBotToken)
     {
-    }
-
-    public function getGuild(int $guildId): Guild
-    {
-        $client = $this->getClient();
-
-        return $client->guild->getGuild([
-            'guild.id' => $guildId,
-        ]);
     }
 
     /**

--- a/src/Model/ApplicationToken.php
+++ b/src/Model/ApplicationToken.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Secret Santa project.
+ *
+ * (c) JoliCode <coucou@jolicode.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace JoliCode\SecretSanta\Model;
+
+class ApplicationToken
+{
+    /**
+     * @param array<string, mixed> $context
+     */
+    public function __construct(
+        private string $token,
+        private array $context = [],
+    ) {
+    }
+
+    public function getToken(): string
+    {
+        return $this->token;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getContext(): array
+    {
+        return $this->context;
+    }
+}


### PR DESCRIPTION
Fix #239 
Trim the tokens for Slack and Discord to make them lighter and not store as much useless info in session as we used too (like emojis).
Also changed some methods a bit for Discord to make less API calls