### PR TITLE
feat(webex): Use Space to fetch user friends, remove admin need

### DIFF
--- a/src/Application/WebexApplication.php
+++ b/src/Application/WebexApplication.php
@@ -12,6 +12,7 @@
 namespace JoliCode\SecretSanta\Application;
 
 use JoliCode\SecretSanta\Model\ApplicationToken;
+use JoliCode\SecretSanta\Model\Group;
 use JoliCode\SecretSanta\Model\SecretSanta;
 use JoliCode\SecretSanta\Model\User;
 use JoliCode\SecretSanta\Webex\MessageSender;
@@ -27,6 +28,11 @@ class WebexApplication implements ApplicationInterface
 
     private const SESSION_KEY_TOKEN = 'santa.webex.token';
     private const SESSION_KEY_ADMIN = 'santa.webex.admin';
+
+    /**
+     * @var array<Group>
+     */
+    private array $groups = [];
 
     public function __construct(
         private RequestStack $requestStack,
@@ -73,12 +79,16 @@ class WebexApplication implements ApplicationInterface
 
     public function getGroups(): array
     {
-        return [];
+        return $this->groups;
     }
 
     public function getUsers(): array
     {
-        return $this->userExtractor->extractAll($this->getToken()->getToken());
+        [$users, $groups] = $this->userExtractor->extractAll($this->getToken()->getToken());
+
+        $this->groups = $groups;
+
+        return $users;
     }
 
     public function sendSecretMessage(SecretSanta $secretSanta, string $giver, string $receiver, bool $isSample = false): void

--- a/src/Controller/SantaController.php
+++ b/src/Controller/SantaController.php
@@ -86,13 +86,15 @@ class SantaController extends AbstractController
 
         $config = $this->getConfigOrThrow404($request);
 
+        // Fetch the users and groups and save them
         if (!$config->getAvailableUsers()) {
             $config->setAvailableUsers($application->getUsers());
+            $config->setGroups($application->getGroups());
+
             $this->saveConfig($request, $config);
         }
 
         $availableUsers = $config->getAvailableUsers();
-
         $form = $this->createForm(ParticipantType::class, $config, [
             'available-users' => $availableUsers,
         ]);
@@ -108,7 +110,7 @@ class SantaController extends AbstractController
 
         $content = $this->twig->render('santa/application/participants_' . $application->getCode() . '.html.twig', ['application' => $application->getCode(),
             'users' => $availableUsers,
-            'groups' => $application->getGroups(),
+            'groups' => $config->getGroups(),
             'form' => $form->createView(),
         ]);
 

--- a/src/Controller/WebexController.php
+++ b/src/Controller/WebexController.php
@@ -60,7 +60,9 @@ class WebexController extends AbstractController
             $options = [
                 'scope' => [
                     'spark:kms', // This scope is required to give your integration permission to interact with encrypted content (such as messages).
-                    'spark-admin:people_read', // Because of this, only an admin can run this app
+                    'spark:memberships_read',
+                    'spark:rooms_read',
+                    'spark:people_read',
                 ],
             ];
             $authUrl = $provider->getAuthorizationUrl($options);

--- a/src/Discord/MessageSender.php
+++ b/src/Discord/MessageSender.php
@@ -51,7 +51,7 @@ Someone will get you a gift and **you have been chosen to gift:**
         }
 
         if (!empty($secretSanta->getAdminMessage())) {
-            $text .= "\n\nHere is a message from the Secret Santa admin:\n\n```" . $secretSanta->getAdminMessage() . '```';
+            $text .= "\n\nHere is a message from the Secret Santa admin:\n\n```\n" . $secretSanta->getAdminMessage() . "\n```";
         } else {
             $text .= "\n\nIf you have any question please ask your Secret Santa admin";
         }

--- a/src/Model/Config.php
+++ b/src/Model/Config.php
@@ -15,6 +15,8 @@ class Config
 {
     /** @var User[] */
     private array $availableUsers = [];
+    /** @var Group[] */
+    private array $groups = [];
     /** @var string[] */
     private array $selectedUsers = [];
     private ?string $message = '';
@@ -117,5 +119,21 @@ class Config
     public function setOptions(array $options): void
     {
         $this->options = $options;
+    }
+
+    /**
+     * @param array<Group> $groups
+     */
+    public function setGroups(array $groups): void
+    {
+        $this->groups = $groups;
+    }
+
+    /**
+     * @return Group[]
+     */
+    public function getGroups(): array
+    {
+        return $this->groups;
     }
 }

--- a/src/Slack/MessageSender.php
+++ b/src/Slack/MessageSender.php
@@ -111,7 +111,7 @@ class MessageSender
                 ],
             ];
 
-            $fallbackText .= sprintf("\n\nHere is a message from the Secret Santa admin:\n\n```%s```", $secretSanta->getAdminMessage());
+            $fallbackText .= sprintf("\n\nHere is a message from the Secret Santa admin:\n\n```\n%s\n```", $secretSanta->getAdminMessage());
         } else {
             $blocks[] = [
                 'type' => 'section',

--- a/src/Webex/MessageSender.php
+++ b/src/Webex/MessageSender.php
@@ -47,7 +47,7 @@ Someone will get you a gift and **you have been chosen to gift:**
         }
 
         if ($secretSanta->getAdminMessage()) {
-            $text .= "\n\nHere is a message from the Secret Santa admin:\n\n```" . $secretSanta->getAdminMessage() . "\n```";
+            $text .= "\n\nHere is a message from the Secret Santa admin:\n\n```\n" . $secretSanta->getAdminMessage() . "\n```";
         } else {
             $text .= "\n\nIf you have any question please ask your Secret Santa admin";
         }

--- a/templates/santa/application/participants_webex.html.twig
+++ b/templates/santa/application/participants_webex.html.twig
@@ -4,7 +4,7 @@
 
 {% macro userSummary(userForm, user) %}
     <span class="user-summary">
-        {% if user.extra.image %}
+        {% if user.extra.image is defined %}
             <img src="{{ user.extra.image }}" alt=""/>
         {% endif %}
         <span>{{ user.name }}</span>
@@ -18,18 +18,17 @@
     <label
             class="user-item"
             for="{{ userForm.vars.id }}"
-            data-search-index="{{ user.name ~ ' ' ~ user.extra.nickname }}"
+            data-search-index="{{ user.name }}"
     >
-
         <div class="data-summary"
              data-summary="{{ current.userSummary(userForm, user)|escape('html_attr')|raw }}"
         >
             {{ form_widget(userForm, {'attr': { 'data-identifier': user.identifier }}) }}
         </div>
 
-        {% if user.extra.image %}
+        {% if user.extra.image is defined %}
             <img src="{{ user.extra.image }}" alt="{{ user.name }}"/>
         {% endif %}
-        <span>{{ user.name }}{% if user.extra.nickname and user.extra.nickname != user.name %} ({{ user.extra.nickname }}){% endif %}</span>
+        <span>{{ user.name }}</span>
     </label>
 {% endblock %}

--- a/templates/santa/participants.html.twig
+++ b/templates/santa/participants.html.twig
@@ -448,6 +448,12 @@
             <div class="error" role="alert">
                 Ooops, we didn't find enough users in your team. You need at least 2 users to start a Secret Santa.
             </div>
+
+            {% if application == 'webex' %}
+                <div class="error" role="alert">
+                    <i class="custom-fa-webex" style="vertical-align: text-bottom;"></i> You need to be in a messaging Space with the people you want to participate with. <a href="{{ path('cancel', { application: 'webex' }) }}">Retry</a>.
+                </div>
+            {% endif %}
         {% endif %}
     </div>
 {% endblock santa_content %}


### PR DESCRIPTION
Refs: #272

After a discussion with the support, they suggested I use the "Spaces" instead of trying to get the whole company directory.

That way the Admin permission is not needed anymore.

Big change: we now store the GROUPS in the Config as well.