### PR TITLE
feat(webex): Handle messages sent to the bot

### DIFF
--- a/src/Controller/WebexController.php
+++ b/src/Controller/WebexController.php
@@ -14,6 +14,7 @@ namespace JoliCode\SecretSanta\Controller;
 use JoliCode\SecretSanta\Application\WebexApplication;
 use JoliCode\SecretSanta\Exception\AuthenticationException;
 use JoliCode\SecretSanta\Model\ApplicationToken;
+use JoliCode\SecretSanta\Webex\MessageSender;
 use JoliCode\SecretSanta\Webex\UserExtractor;
 use JoliCode\SecretSanta\Webex\WebexProvider;
 use League\OAuth2\Client\Token\AccessToken;
@@ -104,5 +105,28 @@ class WebexController extends AbstractController
     public function landing(): Response
     {
         return $this->render('webex/landing.html.twig');
+    }
+
+    #[Route('/bot/webex', name: 'webex_bot', methods: ['POST'])]
+    public function bot(Request $request, MessageSender $messageSender): Response
+    {
+        $eventData = $request->toArray();
+
+        if ('messages' !== $eventData['resource']) {
+            return new Response();
+        }
+
+        if ('created' !== $eventData['event']) {
+            return new Response();
+        }
+
+        // Avoid to answer to ourselves
+        if ('secret-santa@webex.bot' === $eventData['data']['personEmail']) {
+            return new Response();
+        }
+
+        $messageSender->sendDummyBotAnswer($eventData['data']['personId']);
+
+        return new Response();
     }
 }

--- a/src/Webex/MessageSender.php
+++ b/src/Webex/MessageSender.php
@@ -113,4 +113,18 @@ Happy Secret Santa!',
 
         throw new MessageSendFailedException($secretSanta, $secretSanta->getConfig()->getAdmin());
     }
+
+    public function sendDummyBotAnswer(string $string): void
+    {
+        $this->client->request('POST', 'https://webexapis.com/v1/messages', [
+            'auth_bearer' => $this->webexBotToken,
+            'headers' => [
+                'accept' => 'application/json',
+            ],
+            'json' => [
+                'toPersonId' => $string,
+                'markdown' => 'Hello, thanks for reaching out! If you wish to run a Secret Santa, you must go to https://secret-santa.team/landing/webex and start over!',
+            ],
+        ]);
+    }
 }

--- a/templates/content/faq.html.twig
+++ b/templates/content/faq.html.twig
@@ -351,6 +351,18 @@
                             <p>Head over our <a href="{{ path('webex_landing') }}">dedicated Webex tutorial</a> to learn more about adding Secret Santa on Webex.</p>
                         </details>
                     </li>
+                    <li>
+                        <details id="webex-revoke">
+                            <summary>
+                                <h3>
+                                    <p><a href="#webex-revoke"><i class="fas fa-link"></i></a>How do I revoke the permission I gave?</p>
+                                </h3>
+                            </summary>
+                            <p>We are not storing any token or permission - so consider your Webex account already free from all ties with Secret Santa.</p>
+                            <p>Once used, this application will never send you or your contact any message
+                                anymore - it can only do that if you <a href="{{ path('webex_landing') }}">restart the app</a>.</p>
+                        </details>
+                    </li>
                 </ul>
 
                 <h2>Miscellaneous</h2>


### PR DESCRIPTION
When talking with the bot, it's nice to get an answer, even if it's a link to the website.

That's what this PR bring:

![image](https://github.com/jolicode/secret-santa/assets/225704/aa8af3b8-27b4-4204-8271-02501943b8a7)

The only requirement is the creation of a webhook like this:

```
curl -X POST --location "https://webexapis.com/v1/webhooks" \
    -H "Authorization: Bearer BOT-TOKEN" \
    -H "Content-Type: application/json" \
    -d "{
          \"name\": \"production-webhook\",
          \"targetUrl\": \"https://secret-santa.team/bot/webex\",
          \"resource\": \"messages\",
          \"event\": \"created\"
        }"
```

Also added a note in the FAQ regarding revocation.