### PR TITLE
Do not catch HTTP exception for Discord to better handle 403

### DIFF
--- a/src/Discord/ApiHelper.php
+++ b/src/Discord/ApiHelper.php
@@ -67,10 +67,6 @@ class ApiHelper
             ],
         ]);
 
-        if (200 !== $response->getStatusCode()) {
-            throw new \RuntimeException('Failed to create private channel: ' . $response->getContent(false));
-        }
-
         $channel = $response->toArray();
         $channelId = $channel['id'];
 
@@ -100,9 +96,8 @@ class ApiHelper
         // Send message to the private channel
         $response = $this->callApi('POST', "/channels/{$channelId}/messages", $options);
 
-        if (200 !== $response->getStatusCode()) {
-            throw new \RuntimeException('Failed to send private message: ' . $response->getContent(false));
-        }
+        // Force http-client to check the response status code
+        $response->getContent();
     }
 
     /**

--- a/src/Slack/UserExtractor.php
+++ b/src/Slack/UserExtractor.php
@@ -16,7 +16,6 @@ use JoliCode\SecretSanta\Exception\UserExtractionFailedException;
 use JoliCode\SecretSanta\Model\Group;
 use JoliCode\SecretSanta\Model\User;
 use JoliCode\Slack\Api\Model\ObjsUser;
-use JoliCode\Slack\Exception\SlackErrorResponse;
 
 class UserExtractor
 {
@@ -44,17 +43,6 @@ class UserExtractor
                     'limit' => 200,
                     'cursor' => $cursor,
                 ]);
-            } catch (SlackErrorResponse $slackErrorResponse) {
-                if ('ratelimited' === $slackErrorResponse->getErrorCode()) {
-                    sleep(30);
-
-                    $response = $this->clientFactory->getClientForToken($token)->usersList([
-                        'limit' => 200,
-                        'cursor' => $cursor,
-                    ]);
-                } else {
-                    throw new UserExtractionFailedException(SlackApplication::APPLICATION_CODE, 'Could not fetch members in team.', $slackErrorResponse);
-                }
             } catch (\Throwable $t) {
                 throw new UserExtractionFailedException(SlackApplication::APPLICATION_CODE, 'Could not fetch members in team.', $t);
             }


### PR DESCRIPTION
Follow-up of https://github.com/jolicode/secret-santa/pull/307

Also remove retry duplicated logic for Slack client.