### PR TITLE
Fix spoiling code sent to admin

### DIFF
--- a/src/Santa/Spoiler.php
+++ b/src/Santa/Spoiler.php
@@ -19,9 +19,19 @@ class Spoiler
     {
         $givers = [];
 
-        foreach ($santa->getAssociations() as $giver => $receiver) {
-            $giverUser = $santa->getUser($giver);
+        $associations = $santa->getAssociations();
+        $firstGiver = array_key_first($associations);
+        $currentGiver = $firstGiver;
+
+        // Sort givers array to have a consistent order and reduce spoiler size by using a chain
+        // user1 offers to user2 who offers to user3 who offers to ... who offers to user1
+        while ($currentGiver) {
+            $giverUser = $santa->getUser($currentGiver);
             $givers[] = $giverUser->getName() ?: $giverUser->getIdentifier();
+            $currentGiver = $associations[$currentGiver] ?? null;
+            if ($currentGiver === $firstGiver) {
+                break;
+            }
         }
 
         return 'v3@' . base64_encode(gzencode(json_encode($givers)));

--- a/tests/Santa/SpoilerTest.php
+++ b/tests/Santa/SpoilerTest.php
@@ -43,10 +43,10 @@ class SpoilerTest extends TestCase
 
         $secretSanta = new SecretSanta('yolo', [
             'user1' => 'user2',
-            'user2' => 'user3',
             'user3' => 'user4',
-            'user4' => 'user5',
+            'user2' => 'user3',
             'user5' => 'user1',
+            'user4' => 'user5',
         ], $config);
 
         $code = $this->SUT->encode($secretSanta);


### PR DESCRIPTION
Since the introduction of exclusions, the `config->shuffledUsers` (and thus `secretSanta->associations`) can no longer be considered as a chain (ie `user1`  => `user2` then `user2` => `user3`, then `user3` => ...).

So we must now build this chain manually before creating the spoling code, to ensure the lightest possible code.

I kept the `v3` version of the code, because its format did not change.

I also tweaked the test to ensure the spoiling code is valid even when associations is not chained.